### PR TITLE
docs: booting machine requires POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ Let's use the example configuration from above. Your `mbwol` server is at `10.0.
 
 **Goal:** Wake the computer and boot into Windows.
 
-**Action:** Make an HTTP GET request from any device on your network (e.g., your phone, laptop, or a script).
+**Action:** Make an HTTP POST request from any device on your network (e.g., your phone, laptop, or a script).
 
 ```bash
-curl http://10.0.1.1:8000/boot/desktop/windows
+curl -X POST http://10.0.1.1:8000/boot/desktop/windows
 ```
 
 *(Assuming `mbwol` is running on the default port `8000`).*


### PR DESCRIPTION
First of all, loving the project! I've been looking for a clean solution for this exact problem for a while, so this is perfect!

When going through the guide, i noticed a small issue: 
The [http server](https://github.com/bducha/mbwol/blob/5df8624f0180ca4d3dcd3ec6fba14f36cbcfd76c/api/server.go#L19 ) actually only handles POST requests, throwing "Method Not Allowed" if you just navigate to the URL or use the provided command.

This specifies that it needs to be POST request, and adjusts the command.

(another solution would be to make the server actually handle GET requests, but POST seems more intuitive for this purpose)




